### PR TITLE
Enclose ESSIDs with double-quotes in the CSV file

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,9 +59,13 @@ if __name__ == '__main__':
 
                 encryption.sort()
 
+
+            # Escape double-quotes in the ESSID with another double-quote (see RFC-4180)
+            essid = essid.replace('"', '""')
+
             # Store network to csv file
             # If MODE is not specified
             if mode == "" and essid != "":
-                    outfile.write("\n" + essid + "," + bssid + "," + ' '.join(encryption) + "," + gpslat + "," + gpslng)
+                    outfile.write('\n"' + essid + '",' + bssid + ',' + ' '.join(encryption) + ',' + gpslat + ',' + gpslng)
             elif essid != "" and mode == encryption[0]:
-                    outfile.write("\n" + essid + "," + bssid + "," + ' '.join(encryption) + "," + gpslat + "," + gpslng)
+                    outfile.write('\n"' + essid + ',' + bssid + ',' + ' '.join(encryption) + ',' + gpslat + ',' + gpslng)


### PR DESCRIPTION
I had trouble with ESSIDs that included commas. This pull request puts double-quotes around the ESSIDs and escapes double-quotes that are included in the ESSIDs.